### PR TITLE
Split messages with shlex.split, slugify package title to use as name.

### DIFF
--- a/picobot/handlers.py
+++ b/picobot/handlers.py
@@ -38,7 +38,8 @@ def creator_only(func):
 
 
 def build_pack_name(title: str, bot: Bot) -> str:
-    return f'{slugify(title, separator="_")}_by_{bot.username}'
+    slug = slugify(title, separator="_", lowercase=False)
+    return f'{slug}_by_{bot.username}'
 
 
 def start(bot, update):

--- a/picobot/responses.py
+++ b/picobot/responses.py
@@ -49,4 +49,6 @@ ou como resposta a um sticker existente para apenas adicioná-lo ao pack.
     /delsticker <NomeDoPack> <Posição> - remove o sticker do pack (não recuperável)
     /setdefaultpack <NomeDoPack> - configura seu pack padrão
     /setpublic <NomeDoPack> - torna seu pack público (qualquer pessoa pode editá-lo, adicionar e remover stickers)
-    /setprivate <NomeDoPack> - torna seu pack privado para edição (qualquer pessoa ainda pode visualizá-lo e utilizá-lo) """
+    /setprivate <NomeDoPack> - torna seu pack privado para edição (qualquer pessoa ainda pode visualizá-lo e utilizá-lo)
+
+    Para utilizar espaços no nome do pacote, escreva-o entre aspas simples ou duplas."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -286,6 +286,17 @@ version = "1.0.4"
 
 [[package]]
 category = "main"
+description = "A Python Slugify application that handles Unicode"
+name = "python-slugify"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "4.0.0"
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[[package]]
+category = "main"
 description = "We have made you a wrapper you can't refuse"
 name = "python-telegram-bot"
 optional = false
@@ -314,6 +325,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.3.6"
 
 [[package]]
+category = "main"
+description = "The most basic Text::Unidecode port"
+name = "text-unidecode"
+optional = false
+python-versions = "*"
+version = "1.3"
+
+[[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
@@ -330,7 +349,7 @@ python-versions = ">=2.7"
 version = "0.5.2"
 
 [metadata]
-content-hash = "6056f207b7c8564f0816b5db97fd973bbc42e6f986a49caaf05a5bcb7fac4bdb"
+content-hash = "9a4647b2f2414d7215ad88c1916529d3b0b30e5e6d33ea7d403876a8315bfe3b"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -363,8 +382,10 @@ pyflakes = ["17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0", 
 pytest = ["3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec", "e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"]
 python-dateutil = ["7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb", "c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"]
 python-editor = ["1bf6e860a8ad52a14c3ee1252d5dc25b2030618ed80c022598f00176adc8367d", "51fda6bcc5ddbbb7063b2af7509e43bd84bfc32a4ff71349ec7847713882327b", "5f98b069316ea1c2ed3f67e7f5df6c0d8f10b689964a4a811ff64f0106819ec8", "c3da2053dbab6b29c94e43c486ff67206eafbe7eb52dbec7390b5e2fb05aac77", "ea87e17f6ec459e780e4221f295411462e0d0810858e055fc514684350a2f522"]
+python-slugify = ["a8fc3433821140e8f409a9831d13ae5deccd0b033d4744d94b31fea141bdd84c"]
 python-telegram-bot = ["78695b1f6e147e9b360ccfb1ac92b542cab27870ccaf04065a88ee601ffa58b6", "cca4e32ebb8da7fdf35ab2fa2b3edd441211364819c5592fc253acdb7561ea5b"]
 six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
 sqlalchemy = ["217e7fc52199a05851eee9b6a0883190743c4fb9c8ac4313ccfceaffd852b0ff"]
+text-unidecode = ["1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"]
 toml = ["229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c", "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e", "f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"]
 zipp = ["4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a", "8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.7"
 python-telegram-bot = "^11.1"
 dataset = "^1.1"
 pillow = "^6.1"
+python-slugify = "^4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
This enables sticker packs to have more elaborate titles, including special characters and spaces (everything Telegram allows).

To allow for spaces, the user must use quotes around the package title.