### PR TITLE
Add standard avatar for uses with private photos

### DIFF
--- a/picobot/config.py
+++ b/picobot/config.py
@@ -1,8 +1,8 @@
 import json
-from os import environ, path
+from os import environ
 from pathlib import Path
 
-ROOT_DIR = path.dirname(path.abspath(__file__))
+ROOT_DIR = Path(__file__).absolute().parent
 
 try:
     CONFIG_DIR = Path(environ['XDG_CONFIG_HOME'], 'picobot')

--- a/picobot/handlers.py
+++ b/picobot/handlers.py
@@ -13,9 +13,9 @@ from .msg_type import MsgType
 from .painter import sticker_from_image, sticker_from_text
 from .repository.repo import repository
 
-IMG_DIR = ROOT_DIR + '/images/'
-IMG_NAME = 'img'
-AVATAR_NAME = 'avatar'
+IMG_DIR = ROOT_DIR / 'images'
+IMG_PREFIX = 'img'
+AVATAR_PREFIX = 'avatar'
 
 logging.basicConfig(
     filename='picobot.log',
@@ -60,7 +60,7 @@ def create_pack(bot: Bot, update: Update):
 
     title = splittext[1]
     name = build_pack_name(title, bot)
-    png_sticker = open(f'{IMG_DIR}caravela.png', 'rb')
+    png_sticker = open(IMG_DIR / 'caravela.png', 'rb')
     emoji = splittext[2] if len(splittext) > 2 else DEFAULT_EMOJI
 
     # Create Pack
@@ -153,10 +153,11 @@ def add_text(bot: Bot, msg: Message, user_id: int, pack_name: str, emoji: str):
     avatar_path = ''
     try:
         photo = photos[0][0]
-        avatar_path = IMG_DIR + AVATAR_NAME + str(other_user_id) + '.jpg'
+        avatar_path = IMG_DIR / f'{AVATAR_PREFIX}{other_user_id}.jpg'
         bot.get_file(photo.file_id).download(custom_path=avatar_path)
     except Exception:
         msg.reply_text(responses.ERROR_DOWNLOAD_PHOTO)
+        avatar_path = ''
 
     text = msg.reply_to_message.text
     # save as png
@@ -198,7 +199,7 @@ def add_photo(
         photo = msg.reply_to_message.photo[-1]
     else:
         photo = msg.photo[-1]
-    img_path = IMG_DIR + IMG_NAME + str(user_id) + '.jpg'
+    img_path = IMG_DIR / f'{IMG_PREFIX}{user_id}.jpg'
     try:
         bot.get_file(photo.file_id).download(custom_path=img_path)
         # resize and save as png
@@ -239,7 +240,7 @@ def insert_sticker_in_pack(
 ):
     sticker_id = msg.reply_to_message.sticker.file_id
 
-    img_path = IMG_DIR + IMG_NAME + str(user_id) + '.jpg'
+    img_path = IMG_DIR / f'{IMG_PREFIX}{user_id}.jpg'
     try:
         bot.get_file(sticker_id).download(custom_path=img_path)
         # resize and save as png

--- a/picobot/handlers.py
+++ b/picobot/handlers.py
@@ -90,9 +90,8 @@ def add_sticker(bot: Bot, update: Update):
     user_id = msg.from_user.id
     splittext = shlex.split(msg.text)
 
-    title = splittext[1]
-
     if check_msg_format(msg.text):
+        title = splittext[1]
         pack_name = build_pack_name(title, bot)
 
         # check if user is pack's owner
@@ -170,7 +169,7 @@ def add_text(bot: Bot, msg: Message, user_id: int, pack_name: str, emoji: str):
         sticker = bot.get_sticker_set(pack_name).stickers[-1]
         msg.reply_sticker(sticker)
     except Exception as exc:
-        logger.error("Exception on Create Pack. User %d Pack %s", user.id, name)
+        logger.error("Exception on Create Pack. User %s (id %d) Pack %s", username, user_id, pack_name)
         logger.error(exc)
         return False
     finally:

--- a/picobot/responses.py
+++ b/picobot/responses.py
@@ -6,7 +6,7 @@ INVALID_DOC = "O arquivo de imagem deve estar em formato PNG \
 com uma camada transparente e caber em um quadrado 512x512 \
 (um dos lados deve ter 512px e o outro 512px ou menos)."
 
-ERROR_DOWNLOAD_PHOTO = "Erro ao tentar baixar foto do usuário."
+ERROR_DOWNLOAD_PHOTO = "Não foi possível baixar a foto do usuário."
 
 USER_NO_PACK = "Você ainda não tem nenhum pacote de sticker. \
 Por favor, primeiro crie um utilizando o comando /newpack para criar um novo pacote de stickers."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ authors = ["Arthur Mesquita Pickcius <arthur.pickcius@gmail.com>"]
 python = "^3.7"
 python-telegram-bot = "^11.1"
 dataset = "^1.1"
-pillow = "^6.1"
+pillow = "^8.0"
 python-slugify = "^4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"
 flake8 = "^3.7"
 isort = "^4.3"
-black = {version = "^19.10b0", allows-prereleases = true}
+black = {version = "^19.10b0", allow-prereleases = true}
 
 [tool.black]
 skip_string_normalization = true


### PR DESCRIPTION
- When user's privacy setting doesn't allow the bot to download his/her picture, use Telegram's standard "avatar" (a circle with user's initials).
- Also fix some log and error messages.
- Update pillow and black versions